### PR TITLE
Remove the css rule that makes images with width: 100%

### DIFF
--- a/lib/profile-gh/gh.css
+++ b/lib/profile-gh/gh.css
@@ -79,7 +79,3 @@ a {
 a:hover {
     text-decoration: underline;
 }
-
-img {
-    width: 100%;
-}

--- a/lib/profile-npm/npm.css
+++ b/lib/profile-npm/npm.css
@@ -46,7 +46,3 @@ a:link, a:visited, a:active {
     text-decoration: none;
     color: #cc3d33;
 }
-
-img {
-    width: 100%;
-}


### PR DESCRIPTION
Github, npm don't set the width of their images to 100%. With width: 100% images like the "shields"  will be displayed in full width which is not similar to the final expected result for .md files when displayed on github or npm.

<img width="1440" alt="screen shot 2016-03-20 at 2 50 53 am" src="https://cloud.githubusercontent.com/assets/1908658/13902168/5e850bcc-ee46-11e5-9c1c-d78382c600d4.png">
